### PR TITLE
fix(juice-shop): profile image url crash

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -13,7 +13,12 @@ import { UserModel } from '../models/user'
 import * as utils from '../lib/utils'
 import logger from '../lib/logger'
 
-export function profileImageUrlUpload () {
+const stripControlChars = (value: string) => Array.from(value).filter((char) => {
+  const code = char.charCodeAt(0)
+  return code > 31 && code !== 127
+}).join('')
+
+export function profileImageUrlUpload() {
   return async (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
@@ -32,7 +37,7 @@ export function profileImageUrlUpload () {
         } catch (error) {
           try {
             const user = await UserModel.findByPk(loggedInUser.data.id)
-            await user?.update({ profileImage: url })
+            await user?.update({ profileImage: stripControlChars(url) })
             logger.warn(`Error retrieving user profile image: ${utils.getErrorMessage(error)}; using image link directly`)
           } catch (error) {
             next(error)

--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -18,7 +18,7 @@ const stripControlChars = (value: string) => Array.from(value).filter((char) => 
   return code > 31 && code !== 127
 }).join('')
 
-export function profileImageUrlUpload() {
+export function profileImageUrlUpload () {
   return async (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl

--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -23,11 +23,11 @@ const stripControlChars = (value: string) => Array.from(value).filter((char) => 
   return code > 31 && code !== 127
 }).join('')
 
-function favicon() {
+function favicon () {
   return utils.extractFilename(config.get('application.favicon'))
 }
 
-export function getUserProfile() {
+export function getUserProfile () {
   return async (req: Request, res: Response, next: NextFunction) => {
     let template: string
     try {

--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -18,11 +18,16 @@ import * as utils from '../lib/utils'
 
 const entities = new Entities()
 
-function favicon () {
+const stripControlChars = (value: string) => Array.from(value).filter((char) => {
+  const code = char.charCodeAt(0)
+  return code > 31 && code !== 127
+}).join('')
+
+function favicon() {
   return utils.extractFilename(config.get('application.favicon'))
 }
 
-export function getUserProfile () {
+export function getUserProfile() {
   return async (req: Request, res: Response, next: NextFunction) => {
     let template: string
     try {
@@ -84,15 +89,22 @@ export function getUserProfile () {
     template = template.replace(/_logo_/g, utils.extractFilename(config.get('application.logo')))
 
     const fn = pug.compile(template)
-    const CSP = `img-src 'self' ${user?.profileImage}; script-src 'self' 'unsafe-eval' https://code.getmdl.io http://ajax.googleapis.com`
+    const profileImageCspValue = user?.profileImage ? stripControlChars(user.profileImage) : ''
+    const CSP = `img-src 'self' ${profileImageCspValue}; script-src 'self' 'unsafe-eval' https://code.getmdl.io http://ajax.googleapis.com`
 
     challengeUtils.solveIf(challenges.usernameXssChallenge, () => {
       return username && user?.profileImage.match(/;[ ]*script-src(.)*'unsafe-inline'/g) !== null && utils.contains(username, '<script>alert(`xss`)</script>')
     })
 
-    res.set({
-      'Content-Security-Policy': CSP
-    })
+    try {
+      res.set({
+        'Content-Security-Policy': CSP
+      })
+    } catch {
+      res.set({
+        'Content-Security-Policy': "img-src 'self'; script-src 'self' 'unsafe-eval' https://code.getmdl.io http://ajax.googleapis.com"
+      })
+    }
 
     res.send(fn(user))
   }


### PR DESCRIPTION
Juice Shop crashes when we send a request like:


URL='http://localhost:3000/profile/image/url'
TOKEN='TOKEN'
curl -i -X POST "$URL" \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H "Authorization: Bearer $TOKEN" \
  -H "Cookie: language=en; token=$TOKEN" \
  --data-raw 'imageUrl=https%3A%2F%2F%00%2Fimage'
It happens because %00 in the payload becomes a NUL byte (\x00) after decoding.

That bad value gets saved as profileImage during /profile/image/url handling (fallback path), and later /profile uses profileImage to build the Content-Security-Policy header. HTTP headers cannot contain NUL/control characters, so Node throws:

TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Content-Security-Policy"]

That exception was unhandled, so the Node process exits and the pod restarts.

[SET-1946](https://brightsec.atlassian.net/browse/SET-1946)


[SET-1946]: https://brightsec.atlassian.net/browse/SET-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ